### PR TITLE
[FIX] Prototype pollution in deep-get-set

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function deep (obj, path, value) {
 
 function get (obj, path) {
   var keys = Array.isArray(path) ? path : path.split('.');
+  if(keys.includes('__proto__') || keys.includes('prototype') || keys.includes('constructor')) return obj
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
     if (!obj || !hasOwnProp.call(obj, key)) {
@@ -22,12 +23,12 @@ function get (obj, path) {
 
 function set (obj, path, value) {
   var keys = Array.isArray(path) ? path : path.split('.');
+  if(keys.includes('__proto__') || keys.includes('prototype') || keys.includes('constructor')) return value
   for (var i = 0; i < keys.length - 1; i++) {
     var key = keys[i];
     if (deep.p && !hasOwnProp.call(obj, key)) obj[key] = {};
     obj = obj[key];
   }
-  if(keys[i] == '__proto__' || keys[i] == 'prototype' || keys[i] == 'constructor') return value
   obj[keys[i]] = value;
   return value;
 }

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function set (obj, path, value) {
     if (deep.p && !hasOwnProp.call(obj, key)) obj[key] = {};
     obj = obj[key];
   }
+  if(keys[i] == '__proto__' || keys[i] == 'prototype' || keys[i] == 'constructor') return value
   obj[keys[i]] = value;
   return value;
 }


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-deep-get-set

### ⚙️ Description *

The `deep-get-set` package was vulnerable against a `prototype pollution` issue which occured in the `set` and `get` functions.

### 💻 Technical Description *

I used the `Lodash` fix in order to avoid the issue :+1: 

### 🐛 Proof of Concept (PoC) *

```js
// poc.js
const deep = require('deep-get-set');
deep({},['__proto__','polluted'],true);
console.log(polluted);
```
1. `node poc.js` (out: `true)

### 🔥 Proof of Fix (PoF) *

Same steps above with fixed version (out: `undefined`)

### 👍 User Acceptance Testing (UAT)

All ok :+1: 